### PR TITLE
INTERLOK-3555 #comment Update the pom url to point to the right doc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -229,7 +229,7 @@ publishing {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "XSLT and XInclude Config Pre-processors")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/advanced-configuration-pre-processors.html#xinclude")
+        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-configuration-pre-processors?id=xinclude")
         properties.appendNode("target", "3.8.0+")
         properties.appendNode("tags", "xinclude,xslt")
         properties.appendNode("license", "false")


### PR DESCRIPTION
## Motivation
The documentation was broken since we changed the doc site

## Modification
Fix the doc url

## Result
The pom has a correct doc url

## Testing
Check that the new url exists in the POM file after running gradle generatePomFileForMavenJavaPublication.