### PR TITLE
Added deprecated message to pom file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -241,6 +241,7 @@ publishing {
         properties.appendNode("tags", "xinclude,xslt")
         properties.appendNode("license", "false")
         properties.appendNode("repository", "https://github.com/adaptris/interlok-xinclude")
+        properties.appendNode("deprecated", "This component has been deprecated and will be removed in 5.0.0; One of the reasons for this, is the way the Interlok Config Projects and Interlok xincludes pre-processors work with relative paths, i.e. they are not compatible with each other")
       }
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -241,7 +241,7 @@ publishing {
         properties.appendNode("tags", "xinclude,xslt")
         properties.appendNode("license", "false")
         properties.appendNode("repository", "https://github.com/adaptris/interlok-xinclude")
-        properties.appendNode("deprecated", "This component has been deprecated and will be removed in 5.0.0; One of the reasons for this, is the way the Interlok Config Projects and Interlok xincludes pre-processors work with relative paths, i.e. they are not compatible with each other")
+        properties.appendNode("deprecated", "This component has been deprecated and will be removed in 5.0.0")
       }
     }
   }


### PR DESCRIPTION
## Motivation

https://adaptris.atlassian.net/browse/INTERLOK-3728
the UI config projects and the xinc preprocessor isn't working together well (with the paths to the includes)
They are not compatible with each other

## Modification

Added a deprecated message to the pom

## Result

on the ui the use of xinc should be flagged as deprecated

## Testing

The pom file should house the deprecated message.
